### PR TITLE
fs/gpfs: Update component to compile with latest gpfs versions

### DIFF
--- a/ompi/mca/fs/gpfs/Makefile.am
+++ b/ompi/mca/fs/gpfs/Makefile.am
@@ -33,14 +33,9 @@ endif
 
 fs_gpfs_sources = \
 		fs_gpfs_component.c \
-		fs_gpfs_file_close.c \
-		fs_gpfs_file_delete.c \
-		fs_gpfs_file_get_size.c \
 		fs_gpfs_file_open.c \
 		fs_gpfs_file_set_info.c\
 		fs_gpfs_file_get_info.c\
-		fs_gpfs_file_set_size.c \
-		fs_gpfs_file_sync.c \
 		fs_gpfs.c \
 		fs_gpfs.h
 

--- a/ompi/mca/fs/gpfs/fs_gpfs.c
+++ b/ompi/mca/fs/gpfs/fs_gpfs.c
@@ -90,7 +90,7 @@ mca_fs_gpfs_component_file_query (ompio_file_t *fh, int *priority)
     tmp = strchr (fh->f_filename, ':');
     if (!tmp) {
         if (OMPIO_ROOT == fh->f_rank) {
-            fh->f_fstype = mca_fs_base_get_fstype ( fh->f_filename );
+            fh->f_fstype = mca_fs_base_get_fstype ( (char *) fh->f_filename );
         }
 	fh->f_comm->c_coll->coll_bcast (&(fh->f_fstype),
 				       1,

--- a/ompi/mca/fs/gpfs/fs_gpfs.h
+++ b/ompi/mca/fs/gpfs/fs_gpfs.h
@@ -35,11 +35,11 @@ BEGIN_C_DECLS
 int mca_fs_gpfs_component_init_query(bool enable_progress_threads,
 		bool enable_mpi_threads);
 struct mca_fs_base_module_1_0_0_t *
-mca_fs_gpfs_component_file_query(mca_io_ompio_file_t *fh, int *priority);
-int mca_fs_gpfs_component_file_unquery(mca_io_ompio_file_t *file);
+mca_fs_gpfs_component_file_query(ompio_file_t *fh, int *priority);
+int mca_fs_gpfs_component_file_unquery(ompio_file_t *file);
 
-int mca_fs_gpfs_module_init(mca_io_ompio_file_t *file);
-int mca_fs_gpfs_module_finalize(mca_io_ompio_file_t *file);
+int mca_fs_gpfs_module_init(ompio_file_t *file);
+int mca_fs_gpfs_module_finalize(ompio_file_t *file);
 OMPI_MODULE_DECLSPEC extern mca_fs_base_component_2_0_0_t mca_fs_gpfs_component;
 
 /*
@@ -48,22 +48,22 @@ OMPI_MODULE_DECLSPEC extern mca_fs_base_component_2_0_0_t mca_fs_gpfs_component;
  * ******************************************************************
  */
 
-int mca_fs_gpfs_file_open(struct ompi_communicator_t *comm, char *filename,
-		int amode, struct ompi_info_t *info, struct mca_io_ompio_file_t *fh);
-int mca_fs_gpfs_file_close(struct mca_io_ompio_file_t *fh);
+int mca_fs_gpfs_file_open(struct ompi_communicator_t *comm, const char *filename,
+		int amode, struct opal_info_t *info, struct ompio_file_t *fh);
+int mca_fs_gpfs_file_close(struct ompio_file_t *fh);
 int mca_fs_gpfs_file_delete(char *filename, struct ompi_info_t *info);
-int mca_fs_gpfs_file_set_size(struct mca_io_ompio_file_t *fh,
+int mca_fs_gpfs_file_set_size(struct ompio_file_t *fh,
 		OMPI_MPI_OFFSET_TYPE size);
-int mca_fs_gpfs_file_get_size(struct mca_io_ompio_file_t *fh,
+int mca_fs_gpfs_file_get_size(struct ompio_file_t *fh,
 		OMPI_MPI_OFFSET_TYPE * size);
 int mca_fs_gpfs_file_get_amode(struct ompi_file_t *fh, int *amode);
-int mca_fs_gpfs_file_set_info(struct mca_io_ompio_file_t *fh,
+int mca_fs_gpfs_file_set_info(struct ompio_file_t *fh,
 		struct ompi_info_t *info);
-int mca_fs_gpfs_file_get_info(struct mca_io_ompio_file_t *fh,
+int mca_fs_gpfs_file_get_info(struct ompio_file_t *fh,
 		struct ompi_info_t **info_used);
 int mca_fs_gpfs_prefetch_hints(int access_mode,
-		mca_io_ompio_file_t *fh, struct ompi_info_t *info);
-int mca_fs_gpfs_io_selection(mca_io_ompio_file_t *fh,
+		ompio_file_t *fh, struct ompi_info_t *info);
+int mca_fs_gpfs_io_selection(ompio_file_t *fh,
 		struct ompi_info_t *info, struct ompi_info_t *info_selected);
 int mca_fs_gpfs_file_sync(struct ompi_file_t *fh);
 //CN: Is mca_fs_gpfs_file_seek needed at all. Not used anywhere!

--- a/ompi/mca/fs/gpfs/fs_gpfs_file_get_info.c
+++ b/ompi/mca/fs/gpfs/fs_gpfs_file_get_info.c
@@ -11,9 +11,9 @@
  *                         All rights reserved.
  * Copyright (c) 2008-2011 University of Houston. All rights reserved.
  * $COPYRIGHT$
- * 
+ *
  * Additional copyrights may follow
- * 
+ *
  * $HEADER$
  */
 
@@ -38,11 +38,18 @@
  *  Accepts:    - same arguments as MPI_File_get_info()
  *  Returns:    - new info object
  */
- 
- int mca_fs_gpfs_file_get_info(mca_io_ompio_file_t *fh,
-                         ompi_info_t **info_used) {
-    fprintf(stderr, "GPFS GET INFO\n");
-	int ret = OMPI_SUCCESS;
-    ret = MPI_Info_dup(fh->f_info, *info_used);
+
+int mca_fs_gpfs_file_get_info(ompio_file_t *fh,
+                        ompi_info_t **info_used)
+{
+    int ret = OMPI_SUCCESS;
+
+    *info_used = OBJ_NEW(ompi_info_t);
+    if (NULL == *info_used) {
+        return OMPI_ERR_OUT_OF_RESOURCE;
+    }
+
+    ret = ompi_info_dup ((ompi_info_t *)fh->f_info, info_used);
+
     return ret;
 }

--- a/ompi/mca/fs/gpfs/fs_gpfs_file_open.c
+++ b/ompi/mca/fs/gpfs/fs_gpfs_file_open.c
@@ -41,10 +41,10 @@
 
 int
 mca_fs_gpfs_file_open (struct ompi_communicator_t *comm,
-                        char* filename,
+                        const char* filename,
                         int access_mode,
-                        struct ompi_info_t *info,
-                        mca_io_ompio_file_t *fh)
+                        struct opal_info_t *info,
+                        ompio_file_t *fh)
 {
     int amode;
     int old_mask, perm;
@@ -84,7 +84,7 @@ mca_fs_gpfs_file_open (struct ompi_communicator_t *comm,
     }
 
     fh->f_amode=access_mode;
-    mca_fs_gpfs_file_set_info(fh, info);
+    mca_fs_gpfs_file_set_info(fh, (struct ompi_info_t *) info);
 
     return OMPI_SUCCESS;
 }
@@ -93,9 +93,9 @@ int
 mca_fs_gpfs_file_get_amode (ompi_file_t *fh,
                              int *amode)
 {
-    mca_io_ompio_data_t *data;
+    mca_common_ompio_data_t *data;
 
-    data = (mca_io_ompio_data_t *) fh->f_io_selected_data;
+    data = (mca_common_ompio_data_t *) fh->f_io_selected_data;
 
     *amode = data->ompio_fh.f_amode;
 
@@ -107,10 +107,10 @@ int
 mca_fs_gpfs_file_seek(ompi_file_t *fh, OMPI_MPI_OFFSET_TYPE off, int whence) {
     //DEBUG: fprintf(stderr, "GPFS FILE SEEK!");
     int ret = OMPI_SUCCESS;
-    mca_io_ompio_data_t *data;
+    mca_common_ompio_data_t *data;
     OMPI_MPI_OFFSET_TYPE offset, temp_offset;
 
-    data = (mca_io_ompio_data_t *) fh->f_io_selected_data;
+    data = (mca_common_ompio_data_t *) fh->f_io_selected_data;
 
     offset = off * data->ompio_fh.f_etype_size;
 
@@ -139,15 +139,15 @@ mca_fs_gpfs_file_seek(ompi_file_t *fh, OMPI_MPI_OFFSET_TYPE off, int whence) {
             return OMPI_ERROR;
     }
 
-    ret = ompi_io_ompio_set_explicit_offset(&data->ompio_fh, offset
+    ret = mca_common_ompio_set_explicit_offset(&data->ompio_fh, offset
             / data->ompio_fh.f_etype_size);
     return ret;
 }
 
 int mca_fs_gpfs_file_get_position(ompi_file_t *fh, OMPI_MPI_OFFSET_TYPE *offset) {
-    mca_io_ompio_data_t *data;
+    mca_common_ompio_data_t *data;
 
-    data = (mca_io_ompio_data_t *) fh->f_io_selected_data;
+    data = (mca_common_ompio_data_t *) fh->f_io_selected_data;
 
     *offset = data->ompio_fh.f_position_in_file_view
             / data->ompio_fh.f_etype_size;


### PR DESCRIPTION
I updated the gpfs component to match the latest structures and functions definitions and remove compiler wranings.
Disabled mpi info setting for the gpfs option "Data Shipping" since it is no longer supported in the latest gpfs versions.

Signed-off-by: raafatfeki <fekiraafat@gmail.com>